### PR TITLE
Fix: changed overlapping ports in dev

### DIFF
--- a/docker-compose-local_dev.yaml
+++ b/docker-compose-local_dev.yaml
@@ -32,7 +32,7 @@ services:
 
   dashboard:
     ports:
-      - "3000:3000"
+      - "3002:3000"
 
   countly_frontend:
     ports:
@@ -58,5 +58,5 @@ services:
 
   git:
     ports:
-      - "3000:3000"
+      - "3003:3000"
       - "222:22"


### PR DESCRIPTION
Changed the port of Gitea and dashboard in dev, since it is overlapping with the Loopback API.